### PR TITLE
Added precision parameters for function that serializes BloomFilter from String

### DIFF
--- a/src/main/java/com/facebook/presto/bloomfilter/BloomFilterFromString.java
+++ b/src/main/java/com/facebook/presto/bloomfilter/BloomFilterFromString.java
@@ -36,4 +36,16 @@ public class BloomFilterFromString extends AbstractBloomFilterAggregation
         bf.putAll(BloomFilter.newInstance(slice.getBytes()));
         state.setBloomFilter(bf);
     }
+
+    @InputFunction
+    public static void input(
+            BloomFilterState state,
+            @SqlType(VARCHAR) Slice slice,
+            @SqlType(StandardTypes.BIGINT) long expectedInsertions,
+            @SqlType(StandardTypes.DOUBLE) double falsePositivePercentage)
+    {
+        BloomFilter bf = getOrCreateBloomFilter(state, (int) expectedInsertions, falsePositivePercentage);
+        bf.putAll(BloomFilter.newInstance(slice.getBytes()));
+        state.setBloomFilter(bf);
+    }
 }

--- a/src/test/java/com/facebook/presto/bloomfilter/TestBloomFilterQueries.java
+++ b/src/test/java/com/facebook/presto/bloomfilter/TestBloomFilterQueries.java
@@ -90,6 +90,9 @@ public class TestBloomFilterQueries
 
         // Test construction
         assertQuery("WITH a AS (SELECT 'robin' AS uuid), b AS (SELECT bloom_filter(a.uuid) AS bf FROM a), c AS (SELECT to_string(b.bf) AS j FROM b), d AS (SELECT bloom_filter_from_string(c.j) AS bf2 FROM c) SELECT bloom_filter_contains(d.bf2, 'robin'), bloom_filter_contains(d.bf2, 'john') FROM d", "SELECT true, false");
+
+        // Test construction from string with precision
+        assertQuery("WITH a AS (SELECT 'robin' AS uuid), b AS (SELECT bloom_filter(a.uuid, 10, 0.05) AS bf FROM a), c AS (SELECT to_string(b.bf) AS j FROM b), d AS (SELECT bloom_filter_from_string(c.j, 10, 0.05) AS bf2 FROM c) SELECT bloom_filter_contains(d.bf2, 'robin'), bloom_filter_contains(d.bf2, 'john') FROM d", "SELECT true, false");
     }
 
     @Test


### PR DESCRIPTION
At [Jampp](jampp.com) we are using this plugin and writing the serialized BloomFilters as strings.

We use different expected numbers of inserts and false positive percentage than the defaults to construct the BloomFilters that are later serialized to string so I added new parameters to the `bloom_filter_from_string` so that converting them again to BloomFilters works correctly.
